### PR TITLE
Include jq in depends

### DIFF
--- a/depends
+++ b/depends
@@ -19,3 +19,4 @@ lsmod:kmod
 bc
 qemu-nbd:qemu-utils
 kpartx
+jq


### PR DESCRIPTION
Jq is used in stage3_homebridge/00-node-install/01-run.sh

Jq isn't necessarily included in a base distribution (like Raspberry Pi OS Lite) and needs to be installed before stage3_homebridge/00-node-install.01-run.sh can be successfully run. The presence of jq should be checked before running build.sh along with other dependencies. Failure when jq is not installed manifests as a failure to install Node.js.