### PR TITLE
Use central configuration for stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,20 +1,12 @@
-name: 'Stale Bot'
+name: Stale workflow
+
 on:
+  workflow_dispatch:
   schedule:
     - cron: '30 1 * * *'
-  workflow_dispatch:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/stale@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          stale-issue-label: stale
-          exempt-issue-labels: pinned,security
-          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
-          days-before-issue-stale: 30
-          days-before-issue-close: 5
-          days-before-pr-close: -1
-          days-before-pr-stale: -1
+    uses: homebridge/.github/.github/workflows/stale.yml@main
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## :recycle: Current situation

Currently, this repo defines its own workflow files. This results in major code duplication.

## :bulb: Proposed solution

With the new `.github` repo, we introduced a central location to manage common workflow files.
This PR migrates the stale action to use the centrally controlled [stale.yml](https://github.com/homebridge/.github/blob/af549200243328532c627fb8eb44ee0a9af883ad/.github/workflows/stale.yml) of the `.github` repo.

## :gear: Release Notes

No user facing changes.

## :heavy_plus_sign: Additional Information

### Testing

-- 

### Reviewer Nudging

See our [.github](https://github.com/homebridge/.github) repo and GitHubs [Reusing workflows](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows) documentation for more info.
