### PR TITLE
Remove duplicate "the" in Interactive Config option title 7

### DIFF
--- a/stage3_homebridge/01-homebridge/files/hb-config
+++ b/stage3_homebridge/01-homebridge/files/hb-config
@@ -822,7 +822,7 @@ if [ "$INTERACTIVE" = True ]; then
         "4 Extra Packages" "Optional packages, eg. Pi-Hole, Node-RED, UniFi Controller" \
         "5 Nginx Options" "Configure Homebridge Nginx settings" \
         "6 Configure OS" "Open the Raspbian Configuration Tool" \
-        "7 Networking" "Open the the NetworkManager UI" \
+        "7 Networking" "Open the NetworkManager UI" \
         "8 Update" "Update this tool to the latest version" \
         "9 About" "Information about this configuration tool" \
         3>&1 1>&2 2>&3)
@@ -834,7 +834,7 @@ if [ "$INTERACTIVE" = True ]; then
         "4 Extra Packages" "Optional packages, eg. Pi-Hole, Node-RED, UniFi Controller" \
         "5 Nginx Options" "Configure Homebridge Nginx settings" \
         "6 Configure OS" "Open the Raspbian Configuration Tool" \
-        "7 Networking" "Open the the NetworkManager UI" \
+        "7 Networking" "Open the NetworkManager UI" \
         "8 Update" "Update this tool to the latest version" \
         "9 About" "Information about this configuration tool" \
         3>&1 1>&2 2>&3)

--- a/stage3_homebridge/01-homebridge/files/hb-config-new
+++ b/stage3_homebridge/01-homebridge/files/hb-config-new
@@ -711,7 +711,7 @@ if [ "$INTERACTIVE" = True ]; then
         "4 Extra Packages" "Optional packages, eg. Pi-Hole, UniFi Controller" \
         "5 Nginx Options" "Configure Homebridge Nginx settings" \
         "6 Configure OS" "Open the Raspberry Pi OS Configuration Tool" \
-        "7 Networking" "Open the the NetworkManager UI" \
+        "7 Networking" "Open the NetworkManager UI" \
         "8 Update" "Update this tool to the latest version" \
         "9 About" "Information about this configuration tool" \
         3>&1 1>&2 2>&3)
@@ -723,7 +723,7 @@ if [ "$INTERACTIVE" = True ]; then
         "4 Extra Packages" "Optional packages, eg. Pi-Hole, UniFi Controller" \
         "5 Nginx Options" "Configure Homebridge Nginx settings" \
         "6 Configure OS" "Open the Raspberry Pi OS Configuration Tool" \
-        "7 Networking" "Open the the NetworkManager UI" \
+        "7 Networking" "Open the NetworkManager UI" \
         "8 Update" "Update this tool to the latest version" \
         "9 About" "Information about this configuration tool" \
         3>&1 1>&2 2>&3)


### PR DESCRIPTION
Remove double "the"

## :recycle: Current situation

See #107.

## :bulb: Proposed solution

Remove duplicate "the"

## :gear: Release Notes

* Remove duplicate "the" in Interactive Config option title