### PR TITLE
Fix typo: tar.gzz -> tar.gz in ffmpeg cleanup

### DIFF
--- a/stage3_homebridge/05-ffmpeg/01-run.sh
+++ b/stage3_homebridge/05-ffmpeg/01-run.sh
@@ -26,7 +26,7 @@ set -x
 
 wget -q "https://github.com/homebridge/ffmpeg-for-homebridge/releases/download/${FFMPEG_FOR_HOMEBRIDGE_VERSION}/ffmpeg-alpine-${FFMPEG_ARCH}.tar.gz"
 tar xzf "ffmpeg-alpine-${FFMPEG_ARCH}.tar.gz" -C / --no-same-owner
-rm -rf ffmpeg-alpine-${FFMPEG_ARCH}.tar.gzz
+rm -rf "ffmpeg-alpine-${FFMPEG_ARCH}.tar.gz"
 
 ffmpeg || exit 0
 EOF


### PR DESCRIPTION
## :recycle: Current situation
The cleanup command targets `ffmpeg-alpine-${FFMPEG_ARCH}.tar.gzz` (typo), but the downloaded/extracted file is `ffmpeg-alpine-${FFMPEG_ARCH}.tar.gz`. Since `rm -rf` doesn't fail on a missing file, the archive was silently left behind after every build.

## :bulb: Proposed solution
Fixed the typo (`tar.gzz` -> `tar.gz`) and added quotes around the variable for consistency with the `tar xzf` line above.

## :gear: Release Notes
No user-facing changes. Internal build script fix only.